### PR TITLE
Fix URL to the Applications view in Dashboard

### DIFF
--- a/words/developer-guide/documents/render-into-image/_index.md
+++ b/words/developer-guide/documents/render-into-image/_index.md
@@ -82,7 +82,7 @@ BMP File
 {{< tab tabNum="1" >}}
 
 ```JAVA
-# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/#/apps.
+# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/applications.
 # Place `Client Id` in client_id argument. Place `Secret` in client_secret argument.
 curl -v "https://api.aspose.cloud/connect/token" \
 -X POST \
@@ -117,7 +117,7 @@ PNG File
 {{< tab tabNum="1" >}}
 
 ```JAVA
-# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/#/apps.
+# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/applications.
 # Place `Client Id` in client_id argument. Place `Secret` in client_secret argument.
 curl -v "https://api.aspose.cloud/connect/token" \
 -X POST \
@@ -152,7 +152,7 @@ PNG File
 {{< tab tabNum="1" >}}
 
 ```JAVA
-# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/#/apps.
+# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/applications.
 # Place `Client Id` in client_id argument. Place `Secret` in client_secret argument.
 curl -v "https://api.aspose.cloud/connect/token" \
 -X POST \
@@ -187,7 +187,7 @@ PDF File
 {{< tab tabNum="1" >}}
 
 ```JAVA
-# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/#/apps.
+# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/applications.
 # Place `Client Id` in client_id argument. Place `Secret` in client_secret argument.
 curl -v "https://api.aspose.cloud/connect/token" \
 -X POST \

--- a/words/developer-guide/headers-and-footers/get/_index.md
+++ b/words/developer-guide/headers-and-footers/get/_index.md
@@ -87,7 +87,7 @@ curl -v "https://api.aspose.cloud/v4.0/words/HeadersFooters.doc/headersfooters/0
 {{< tab tabNum="1" >}}
 
 ```JAVA
-# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/#/apps.
+# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/applications.
 # Place `Client Id` in client_id argument. Place `Secret` in client_secret argument.
 curl -v "https://api.aspose.cloud/connect/token" \
 -X POST \

--- a/words/developer-guide/mail-merge/populate-with-data-online/_index.md
+++ b/words/developer-guide/mail-merge/populate-with-data-online/_index.md
@@ -79,7 +79,7 @@ Feel free to download and explore sample input [TestExecuteTemplate.doc](/words/
 {{< tab tabNum="1" >}}
 
 ```JAVA
-# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/#/apps.
+# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/applications.
 # Place `Client Id` in client_id argument. Place `Secret` in client_secret argument.
 curl -v "https://api.aspose.cloud/connect/token" \
 -X POST \

--- a/words/developer-guide/range/_index.md
+++ b/words/developer-guide/range/_index.md
@@ -129,7 +129,7 @@ First, he needs to call [Paragraph API](https://apireference.aspose.cloud/words/
 {{< tab tabNum="1" >}}
 
 ```JAVA
-# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/#/apps.
+# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/applications.
 # Place `Client Id` in client_id argument. Place `Secret` in client_secret argument.
 curl -v "https://api.aspose.cloud/connect/token" \
 -X POST \
@@ -226,7 +226,7 @@ First, he needs to call [Paragraph API](https://apireference.aspose.cloud/words/
 {{< tab tabNum="1" >}}
 
 ```JAVA
-# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/#/apps.
+# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/applications.
 # Place `Client Id` in client_id argument. Place `Secret` in client_secret argument.
 curl -v "https://api.aspose.cloud/connect/token" \
 -X POST \

--- a/words/getting-started/available-sdks/_index.md
+++ b/words/getting-started/available-sdks/_index.md
@@ -90,7 +90,7 @@ To make these requests you need to get **JSON Web Token** (JWT).
 {{< tab tabNum="1" >}}
 
 ```bash
-# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/#/apps.
+# Please get your `Client Id` and `Secret` credentials from https://dashboard.aspose.cloud/applications.
 # Place `Client Id` in client_id argument. Place `Secret` in client_secret argument.
 curl -v "https://api.aspose.cloud/connect/token" \
 -X POST \


### PR DESCRIPTION
A new dashboard has been launched and URLs have been changed.
Also, AppSID and AppKey were totally replaced with ClientId and ClientSecret.
A lot of GISTS files needs updates (https://gist.github.com/aspose-cloud) and also the SDKs to follow the new naming convention.